### PR TITLE
fix: Clangd works properly, and added JLink launch config that works with STM32 VS Code

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,23 @@
+---
+If:
+  PathMatch: "firmware/components/drd/.*"
+CompileFlags:
+  CompilationDatabase: firmware/components/drd/build/Debug
+---
+
+If:
+  PathMatch: "firmware/components/mdi/.*"
+CompileFlags:
+  CompilationDatabase: firmware/components/mdi/build/Debug
+
+---
+If:
+  PathMatch: "firmware/components/tel/.*"
+CompileFlags:
+  CompilationDatabase: firmware/components/tel/build/Debug
+  
+---
+If:
+  PathMatch: "firmware/common/.*"
+CompileFlags:
+  CompilationDatabase: firmware/components/drd/build/Debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,20 @@
           "imageFileName": "${command:cmake.launchTargetPath}",
         }
       ]
+    },
+    {
+      "name": "J-LINK NO SWO (active ELF path)",
+      "type": "jlinkgdbtarget",
+      "request": "launch",
+      "deviceName": "STM32F103RCT6",
+      "deviceCore": "Cortex-M3",
+      "cwd": "${workspaceFolder}",
+      "runEntry": "main",
+      "imagesAndSymbols": [
+        {
+          "imageFileName": "${command:cmake.launchTargetPath}",
+        }
+      ]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,28 +10,23 @@
     "-DCMAKE_COMMAND=cube-cmake",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
   ],
-  "cmake.preferredGenerators": ["Ninja"],
-
-  "editor.formatOnSave": true,
-
+  "cmake.preferredGenerators": [
+    "Ninja"
+  ],
+  "editor.formatOnSave": false,
   "[c]": {
     "editor.defaultFormatter": "STMicroelectronics.stm32cube-ide-clangd"
   },
   "[cpp]": {
     "editor.defaultFormatter": "STMicroelectronics.stm32cube-ide-clangd"
   },
-
-
   "stm32cube-ide-clangd.path": "cube",
   "stm32cube-ide-clangd.arguments": [
     "starm-clangd",
     "--clang-tidy",
-    "--compile-commands-dir=${sourceDirectory}/build",
     "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/13.3.1+st.9/bin/arm-none-eabi-gcc",
     "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/13.3.1+st.9/bin/arm-none-eabi-g++"
   ],
-
-  
   "editor.codeActionsOnSave": {
     "source.fixAll": "never",
     "source.organizeImports": "never"


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
- Add a .clangd configuration file to specify the compilation database for each project. This should resolve issues we were having with .clangd not working properly.

- one work around: for the common folder, we have to specify  the compilation database from one of the projects (DRD, MDI, BMS, ETC). I put this as the DRD for now, so the DRD has to be compiled for this to work. However, .clangd is in the git ignore, so devs can easily change the path to be their project, and not have to build the DRD after that.


## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] BMS
- [ ] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
