### PR TITLE
[Feat]: Added Simulate CAN Bus script

### DIFF
--- a/tools/Simulate_CAN_Bus/README.md
+++ b/tools/Simulate_CAN_Bus/README.md
@@ -3,5 +3,7 @@
 
 The above will get your environment set up with the right libraries.
 
+3. Now, run `python main.py` inside the `/Simulate_CAN_Bus` folder!
+
 ## Usage
 1. Change `can_messages.yaml` to send the CAN messages you want. `num_messages_in_burst` is the number of messages you will send with a **1 millisecond** delay. These bursts happen every `interval` milliseconds. `board_delay` is the time in milliseconds before that ID starts sending once you run the script. This is to imitate the startup behavior of the car so your tests actually match what happens on the car!

--- a/tools/Simulate_CAN_Bus/README.md
+++ b/tools/Simulate_CAN_Bus/README.md
@@ -1,0 +1,7 @@
+1. Run `./setup.sh`
+2. Run `source environment/bin/activate`
+
+The above will get your environment set up with the right libraries.
+
+## Usage
+1. Change `can_messages.yaml` to send the CAN messages you want. `num_messages_in_burst` is the number of messages you will send with a **1 millisecond** delay. These bursts happen every `interval` milliseconds. `board_delay` is the time in milliseconds before that ID starts sending once you run the script. This is to imitate the startup behavior of the car so your tests actually match what happens on the car!

--- a/tools/Simulate_CAN_Bus/can_messages.yaml
+++ b/tools/Simulate_CAN_Bus/can_messages.yaml
@@ -1,0 +1,259 @@
+# - ID: "0x08850225"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 254
+  
+# - ID: "0x622"
+#   interval: 100
+#   data: "00000000000000"
+#   dlc: 7
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# - ID: "0x623"
+#   interval: 100
+#   data: "000000000000"
+#   dlc: 6
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# - ID: "0x624"
+#   interval: 100
+#   data: "00000000000000"
+#   dlc: 7
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# - ID: "0x625"
+#   interval: 100
+#   data: "0000000000"
+#   dlc: 5
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# - ID: "0x626"
+#   interval: 100
+#   data: "0000000000"
+#   dlc: 5
+#   num_msgs_sent_in_burst: 8         # 8 multiplexed messages sent in a burst
+#   board_delay: 0
+
+# - ID: "0x627"
+#   interval: 100
+#   data: "0000000000"
+#   dlc: 5
+#   num_msgs_sent_in_burst: 8  
+#   board_delay: 0
+
+# - ID: "0x628"
+#   interval: 100
+#   data: "0000000000"
+#   dlc: 5
+#   num_msgs_sent_in_burst: 8
+#   board_delay: 0
+
+# - ID: "0x629"
+#   interval: 100
+#   data: "00000000"
+#   dlc: 4
+#   num_msgs_sent_in_burst: 1
+#   board_delay: 0
+
+# - ID: "0x450"
+#   interval: 200
+#   data: "0000000000000000"
+#   dlc: 6
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# # - ID: "0x1806E5F4"
+# #   interval: 1000
+# #   data: "000000000000000000"
+# #   dlc: 8
+# #   num_msgs_sent_in_burst: 1  
+# #   board_delay: 145
+
+# # - ID: "0x18FF50E5"
+# #   interval: 1000
+# #   data: "000000000000000000"
+# #   dlc: 8
+# #   num_msgs_sent_in_burst: 1  
+# #   board_delay: 145
+
+# - ID: "0x08F89540"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 127
+
+# - ID: "0x08850225"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 254
+
+# - ID: "0x08950225"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 254
+
+# - ID: "0x08A50225"
+#   interval: 100
+#   data: "00000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 254
+
+# - ID: "0x403"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 381
+
+# - ID: "0x404"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 381
+
+# - ID: "0x401"
+#   interval: 25
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 381
+
+# - ID: "0x300"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 0
+
+# - ID: "0x750"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x751"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x752"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x753"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x754"
+#   interval: 100
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x755"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x756"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x757"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x758"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x759"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x760"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+
+# - ID: "0x761"
+#   interval: 250
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 508
+  
+# - ID: "0x500"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 635
+
+# - ID: "0x501"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 635
+  
+- ID: "0x580"
+  interval: 500
+  data: "0000000000000000"
+  dlc: 8
+  num_msgs_sent_in_burst: 1  
+  board_delay: 630
+
+# - ID: "0x581"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 635
+  
+# - ID: "0x582"
+#   interval: 1000
+#   data: "0000000000000000"
+#   dlc: 8
+#   num_msgs_sent_in_burst: 1  
+#   board_delay: 635
+  

--- a/tools/Simulate_CAN_Bus/main.py
+++ b/tools/Simulate_CAN_Bus/main.py
@@ -1,0 +1,136 @@
+import can
+import time
+import yaml
+import signal
+import threading
+from pathlib import Path
+import datetime
+
+# ANSI color for yellow
+ANSI_YELLOW = "\033[33m"
+ANSI_RESET = "\033[0m"
+    
+RATE_SCALER = 1
+MSG_COUNT_IDX = 3
+
+global can_messages 
+can_messages = {}
+
+# Create a global lock for CAN bus access
+bus_lock = threading.Lock()
+
+def get_rtc_data():
+    """
+    Get the current time and format it into an 8-byte data payload.
+    The first six bytes are:
+      Byte 0: Second
+      Byte 1: Minute
+      Byte 2: Hour
+      Byte 3: Day
+      Byte 4: Month
+      Byte 5: Year (last two digits)
+    Byte 6 and 7 are reserved and set to zero.
+    """
+    now = datetime.datetime.now() + datetime.timedelta(hours=7)
+    # Extract each element and ensure they fit in one byte (0-255)
+    sec    = now.second        & 0xFF  # Byte 0
+    minute = now.minute        & 0xFF  # Byte 1
+    hour   = now.hour          & 0xFF  # Byte 2
+    day    = now.day           & 0xFF  # Byte 3
+    month  = now.month         & 0xFF  # Byte 4
+    year   = (now.year % 100)  & 0xFF  # Byte 5 (e.g., 2025 -> 25)
+
+    # Build an 8-byte array. Bytes 6 and 7 are reserved (set to 0).
+    data = bytearray(8)
+    data[0] = sec
+    data[1] = minute
+    data[2] = hour
+    data[3] = day
+    data[4] = month
+    data[5] = year
+    data[6] = 0  # Reserved
+    data[7] = 0  # Reserved
+
+    print("gei", sec, minute, hour, day, month, year)
+
+    return data
+
+def load_can_messages(filename):
+    # Use Path to handle the file path
+    path = Path(__file__).parent / filename
+    with open(path, 'r') as file:
+        messages = yaml.safe_load(file)
+    
+    for msg in messages:
+        # Keep ID as a string
+        can_id = str(msg['ID'])
+        # Convert interval to seconds
+        interval = msg['interval'] / 1000.0
+        # Convert hex string data to a byte list
+        data = [int(msg['data'][i:i+2], 16) for i in range(0, len(msg['data']), 2)]
+        dlc = msg['dlc']  # Data Length Code
+        board_delay = msg['board_delay'] / 1000.0
+        num_in_burst = msg['num_msgs_sent_in_burst']
+
+        count = 0
+        can_messages[can_id] = [interval, data, dlc, count, board_delay, num_in_burst]
+
+# Signal handler for graceful shutdown
+def signal_handler(sig, frame):
+    print(ANSI_YELLOW + "\nExiting... Here are the message counts:" + ANSI_RESET)
+    total_count = 0
+    for can_id, message_data in can_messages.items():
+        count = message_data[MSG_COUNT_IDX]
+        total_count += count
+        print(ANSI_YELLOW  + f"ID: {can_id}, Count: {count}" + ANSI_RESET)
+
+    print(ANSI_YELLOW + f"Total count: {total_count}" + ANSI_RESET)
+    exit(0)
+
+# Function to send a specific CAN message
+def send_message(bus, can_id, data, rate, dlc, board_delay, num_in_burst):    
+    time.sleep(board_delay)
+
+    is_extended = False if int(can_id[2:], 16) <= 0x7FF else True
+
+    while True:
+        try:
+            if (int(can_id[2:], 16) == 0x300):
+                data = get_rtc_data()
+                dlc = 8  # Data Length Code for 8 bytes.
+                message = can.Message(
+                    arbitration_id=int(can_id, 16),
+                    data=data[:dlc],
+                    is_extended_id=is_extended
+                )
+            else:
+                message = can.Message(arbitration_id=int(can_id, 16), data=data[:dlc], is_extended_id=is_extended)
+            for num_msgs in range(num_in_burst):
+                # Lock the bus to ensure exclusive access for sending
+                with bus_lock:
+                    bus.send(message)
+                    can_messages[can_id][MSG_COUNT_IDX] += 1
+                    print(f"ID: {can_id}, Count: {can_messages[can_id][MSG_COUNT_IDX]}")
+                    time.sleep(0.001)
+        except can.CanError as e:
+            print(f"Message NOT sent {e}") 
+        time.sleep(rate * RATE_SCALER)
+
+def send_can_messages():
+    bus = can.interface.Bus(channel='can0', interface='socketcan')
+    load_can_messages('can_messages.yaml')
+
+    threads = []
+    for can_id, [interval, data, dlc, count, board_delay, num_in_burst] in can_messages.items():
+        thread = threading.Thread(target=send_message, args=(bus, can_id, data, interval, dlc, board_delay, num_in_burst))
+        thread.start()
+        threads.append(thread)
+    
+    for thread in threads:
+        thread.join()
+
+if __name__ == "__main__":
+    # Set up signal handler
+    signal.signal(signal.SIGQUIT, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    send_can_messages()

--- a/tools/Simulate_CAN_Bus/requirements.txt
+++ b/tools/Simulate_CAN_Bus/requirements.txt
@@ -1,0 +1,2 @@
+python-can==4.6.1
+PyYAML==6.0.2

--- a/tools/Simulate_CAN_Bus/setup.sh
+++ b/tools/Simulate_CAN_Bus/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e  # Exit immediately if a command fails
+
+ENV_NAME="environment"
+
+echo "Creating virtual environment..."
+python3 -m venv $ENV_NAME
+
+echo "Activating environment..."
+source $ENV_NAME/bin/activate
+
+echo "Upgrading pip..."
+python -m pip install --upgrade pip
+
+echo "Installing requirements..."
+pip install -r requirements.txt
+
+echo ""
+echo "======================================"
+echo " Environment setup complete."
+echo " To activate later, run:"
+echo " source $ENV_NAME/bin/activate"
+echo "======================================"


### PR DESCRIPTION
## Pull Request Description
<!-- Describe your PR here -->
Use `setup.sh` to set the environment. Edit the yaml to send CAN according to your desires. `python main.py` will actually start it. 

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] BMS
- [ ] DRD
- [ ] ECU
- [ ] MDI
- [ ] STR
- [ ] TEL
- [ ] CI/CD


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [X] Bench top testing
- [ ] Unit testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table updated
- IOC updated and commited
- gitignore updated and commited
- [X] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
Previous Fw v3 repo's Simulate CAN Bus was copied over.